### PR TITLE
Convert portfolio pages into a single scrollable homepage

### DIFF
--- a/app/epitech/page.tsx
+++ b/app/epitech/page.tsx
@@ -1,0 +1,16 @@
+export const metadata = {
+  title: "Epitech | Ben Desprets",
+  description: "Notes on Ben Desprets' software engineering studies at Epitech.",
+};
+
+export default function EpitechPage() {
+  return (
+    <article className="document-prose prose prose-neutral dark:prose-invert">
+      <h1>Epitech</h1>
+      <p>
+        Notes on my software engineering studies at Epitech. More detail will
+        live here soon.
+      </p>
+    </article>
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -249,8 +249,15 @@
 }
 
 .page-scroll-section + .page-scroll-section {
-  margin-top: 4rem;
-  padding-top: 0.4rem;
+  margin-top: 4.5rem;
+}
+
+.page-scroll-section > :first-child {
+  margin-top: 0 !important;
+}
+
+.page-scroll-section > :last-child {
+  margin-bottom: 0 !important;
 }
 
 .compact-table {
@@ -371,19 +378,15 @@
 }
 
 .document-prose :where(h1):not(:where([class~="not-prose"] *)) {
-  margin-top: 3.2rem;
+  margin-top: 2.8rem;
   margin-bottom: 0.9rem;
   font-size: clamp(1.5rem, 3vw, 1.95rem);
   font-weight: 600;
   letter-spacing: -0.03em;
 }
 
-.document-prose > :where(h1):first-child:not(:where([class~="not-prose"] *)) {
-  margin-top: 0;
-}
-
 .document-prose :where(h2):not(:where([class~="not-prose"] *)) {
-  margin-top: 3.2rem;
+  margin-top: 2.8rem;
   margin-bottom: 0.8rem;
   font-size: clamp(1.16rem, 2.2vw, 1.38rem);
   font-weight: 600;

--- a/app/globals.css
+++ b/app/globals.css
@@ -148,7 +148,14 @@
   grid-template-columns: 1fr auto 1fr;
   gap: 1.5rem;
   align-items: baseline;
-  margin-bottom: 4.5rem;
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  margin: -0.75rem 0 3.75rem;
+  padding: 0.75rem 0;
+  background: color-mix(in srgb, var(--background) 88%, transparent);
+  border-bottom: 1px solid transparent;
+  backdrop-filter: blur(12px);
   font-size: 0.96rem;
 }
 
@@ -178,14 +185,13 @@
 .site-nav {
   display: inline-flex;
   align-items: center;
-  gap: 0.45rem;
+  gap: 1rem;
   color: var(--muted);
 }
 
 .site-nav-item {
   display: inline-flex;
   align-items: center;
-  gap: 0.45rem;
 }
 
 .site-nav a {
@@ -236,6 +242,15 @@
 
 .site-main {
   min-height: 60vh;
+}
+
+.page-scroll-section {
+  scroll-margin-top: 5.5rem;
+}
+
+.page-scroll-section + .page-scroll-section {
+  margin-top: 4rem;
+  padding-top: 0.4rem;
 }
 
 .project-table {
@@ -452,7 +467,7 @@
 @media (max-width: 560px) {
   .site-header {
     grid-template-columns: 1fr auto;
-    margin-bottom: 3rem;
+    margin-bottom: 2.5rem;
     gap: 0.45rem 0.8rem;
     align-items: start;
   }

--- a/app/globals.css
+++ b/app/globals.css
@@ -153,6 +153,7 @@
   z-index: 10;
   margin: -0.75rem 0 3.75rem;
   padding: 0.75rem 0;
+  background: var(--background);
   background: color-mix(in srgb, var(--background) 88%, transparent);
   border-bottom: 1px solid transparent;
   backdrop-filter: blur(12px);

--- a/app/globals.css
+++ b/app/globals.css
@@ -298,7 +298,7 @@
 }
 
 .project-table__years {
-  width: 6.6rem;
+  width: 7.35rem;
   color: var(--muted);
   white-space: nowrap;
 }
@@ -317,7 +317,7 @@
 }
 
 .education-table td:first-child {
-  width: 6.6rem;
+  width: 7.35rem;
   color: var(--muted);
   white-space: nowrap;
 }
@@ -485,7 +485,7 @@
   }
 
   .project-table__years {
-    width: 6.15rem;
+    width: 6.9rem;
   }
 
   .compact-table th,
@@ -504,7 +504,7 @@
   }
 
   .education-table td:first-child {
-    width: 6.15rem;
+    width: 6.9rem;
   }
 }
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -379,7 +379,7 @@
 }
 
 .document-prose :where(h1):not(:where([class~="not-prose"] *)) {
-  margin-top: 2.8rem;
+  margin-top: 0;
   margin-bottom: 0.9rem;
   font-size: clamp(1.5rem, 3vw, 1.95rem);
   font-weight: 600;
@@ -387,7 +387,7 @@
 }
 
 .document-prose :where(h2):not(:where([class~="not-prose"] *)) {
-  margin-top: 2.8rem;
+  margin-top: 0;
   margin-bottom: 0.8rem;
   font-size: clamp(1.16rem, 2.2vw, 1.38rem);
   font-weight: 600;
@@ -403,6 +403,10 @@
   :where(ul, ol, table):not(:where([class~="not-prose"] *)) {
   margin-top: 0;
   margin-bottom: 1.35rem;
+}
+
+.document-prose :where(.compact-table):not(:where([class~="not-prose"] *)) {
+  margin-bottom: 2.8rem;
 }
 
 .document-prose :where(p):not(:where([class~="not-prose"] *)) {

--- a/app/globals.css
+++ b/app/globals.css
@@ -185,13 +185,14 @@
 .site-nav {
   display: inline-flex;
   align-items: center;
-  gap: 1rem;
+  gap: 0.45rem;
   color: var(--muted);
 }
 
 .site-nav-item {
   display: inline-flex;
   align-items: center;
+  gap: 0.45rem;
 }
 
 .site-nav a {

--- a/app/globals.css
+++ b/app/globals.css
@@ -311,7 +311,7 @@
   display: inline-flex;
 }
 
-.project-table__content .subtle {
+.compact-table .subtle {
   margin-top: 0.12rem;
   margin-bottom: 0;
 }
@@ -495,7 +495,7 @@
     padding-right: 0.8rem;
   }
 
-  .project-table__content .subtle {
+  .compact-table .subtle {
     margin-top: 0.12rem;
   }
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -253,28 +253,44 @@
   padding-top: 0.4rem;
 }
 
-.project-table {
+.compact-table {
   width: 100%;
   border-collapse: collapse;
-  margin-top: 0.15rem;
+  table-layout: fixed;
+  margin-top: 0.1rem;
+  font-variant-numeric: tabular-nums;
 }
 
-.project-table tbody tr {
+.compact-table tr {
   border-top: 1px solid var(--border);
 }
 
-.project-table tbody tr:last-child {
+.compact-table tr:last-child {
   border-bottom: 1px solid var(--border);
 }
 
-.project-table td {
-  padding: 0.62rem 0 0.38rem;
+.compact-table th,
+.compact-table td {
+  padding: 0.68rem 0;
   vertical-align: top;
 }
 
-.project-table__years {
-  width: 6.75rem;
+.compact-table th {
+  color: var(--muted);
+  font-weight: 500;
+}
+
+.compact-table th:not(:last-child),
+.compact-table td:not(:last-child) {
   padding-right: 1rem;
+}
+
+.compact-table p {
+  margin-bottom: 0;
+}
+
+.project-table__years {
+  width: 6.6rem;
   color: var(--muted);
   white-space: nowrap;
 }
@@ -288,7 +304,18 @@
 }
 
 .project-table__content .subtle {
-  margin-top: 0.16rem;
+  margin-top: 0.12rem;
+  margin-bottom: 0;
+}
+
+.education-table td:first-child {
+  width: 6.6rem;
+  color: var(--muted);
+  white-space: nowrap;
+}
+
+.education-table strong {
+  font-weight: 500;
 }
 
 .inline-list {
@@ -445,22 +472,31 @@
     padding: 1.25rem 1.1rem 3rem;
   }
 
-  table {
-    font-size: 0.95rem;
+  .compact-table {
+    table-layout: auto;
   }
 
   .project-table__years {
-    width: 6.35rem;
-    padding-right: 0.85rem;
+    width: 6.15rem;
   }
 
-  .project-table td {
-    padding-top: 0.56rem;
-    padding-bottom: 0.34rem;
+  .compact-table th,
+  .compact-table td {
+    padding-top: 0.58rem;
+    padding-bottom: 0.58rem;
+  }
+
+  .compact-table th:not(:last-child),
+  .compact-table td:not(:last-child) {
+    padding-right: 0.8rem;
   }
 
   .project-table__content .subtle {
     margin-top: 0.12rem;
+  }
+
+  .education-table td:first-child {
+    width: 6.15rem;
   }
 }
 

--- a/app/mcgill/page.tsx
+++ b/app/mcgill/page.tsx
@@ -1,0 +1,16 @@
+export const metadata = {
+  title: "McGill | Ben Desprets",
+  description: "Notes on Ben Desprets' management studies at McGill.",
+};
+
+export default function McGillPage() {
+  return (
+    <article className="document-prose prose prose-neutral dark:prose-invert">
+      <h1>McGill</h1>
+      <p>
+        Notes on my management studies at McGill. More detail will live here
+        soon.
+      </p>
+    </article>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,9 +1,23 @@
 import HomePageContent from "@/content/homepage.mdx";
+import WorkContent from "@/content/work.mdx";
+import AboutContent from "@/content/about.mdx";
+import ContactContent from "@/content/contact.mdx";
 
 export default function Home() {
   return (
     <article className="document-prose prose prose-neutral dark:prose-invert">
-      <HomePageContent />
+      <section id="home" className="page-scroll-section" aria-label="Home">
+        <HomePageContent />
+      </section>
+      <section id="work" className="page-scroll-section" aria-label="Work">
+        <WorkContent />
+      </section>
+      <section id="about" className="page-scroll-section" aria-label="About">
+        <AboutContent />
+      </section>
+      <section id="contact" className="page-scroll-section" aria-label="Contact">
+        <ContactContent />
+      </section>
     </article>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,19 +1,19 @@
-import HomePageContent from "@/content/homepage.mdx";
-import WorkContent from "@/content/work.mdx";
 import AboutContent from "@/content/about.mdx";
+import WorkContent from "@/content/work.mdx";
+import EducationContent from "@/content/education.mdx";
 import ContactContent from "@/content/contact.mdx";
 
 export default function Home() {
   return (
     <article className="document-prose prose prose-neutral dark:prose-invert">
-      <section id="home" className="page-scroll-section" aria-label="Home">
-        <HomePageContent />
+      <section id="about" className="page-scroll-section" aria-label="About">
+        <AboutContent />
       </section>
       <section id="work" className="page-scroll-section" aria-label="Work">
         <WorkContent />
       </section>
-      <section id="about" className="page-scroll-section" aria-label="About">
-        <AboutContent />
+      <section id="education" className="page-scroll-section" aria-label="Education">
+        <EducationContent />
       </section>
       <section id="contact" className="page-scroll-section" aria-label="Contact">
         <ContactContent />

--- a/components/homepage-content.tsx
+++ b/components/homepage-content.tsx
@@ -1,16 +1,8 @@
-import type { ComponentPropsWithoutRef, ReactNode } from "react";
+import type { ComponentPropsWithoutRef } from "react";
 import Link from "next/link";
 import { ArrowUpRight } from "lucide-react";
 import { clientWork } from "@/app/client-work";
 import { projects } from "@/app/projects";
-
-interface SubtleProps {
-  children: ReactNode;
-}
-
-export function Subtle({ children }: SubtleProps) {
-  return <div className="subtle">{children}</div>;
-}
 
 type LinkProps = ComponentPropsWithoutRef<"a">;
 

--- a/components/homepage-content.tsx
+++ b/components/homepage-content.tsx
@@ -31,7 +31,7 @@ export function ExternalLink({
 
 export function ProjectsSection() {
   return (
-    <table className="project-table">
+    <table className="project-table compact-table">
       <tbody>
       {projects.map((project) => {
         return (
@@ -51,7 +51,7 @@ export function ProjectsSection() {
 
 export function ClientWorkSection() {
   return (
-    <table className="project-table">
+    <table className="project-table compact-table">
       <tbody>
       {clientWork.map((client) => {
         return (

--- a/components/site-nav.tsx
+++ b/components/site-nav.tsx
@@ -84,8 +84,9 @@ export function SiteNav() {
 
   return (
     <nav aria-label="Primary" className="site-nav">
-      {navItems.map((item) => (
+      {navItems.map((item, index) => (
         <span key={item.href} className="site-nav-item">
+          {index > 0 ? <span aria-hidden="true">/</span> : null}
           <Link
             href={item.href}
             data-active={activeSection === item.sectionId}

--- a/components/site-nav.tsx
+++ b/components/site-nav.tsx
@@ -6,15 +6,15 @@ import type { MouseEvent } from "react";
 import { useEffect, useState } from "react";
 
 const navItems = [
-  { href: "/#home", label: "home", sectionId: "home", path: "/" },
-  { href: "/#work", label: "work", sectionId: "work", path: "/work" },
   { href: "/#about", label: "about", sectionId: "about", path: "/about" },
+  { href: "/#work", label: "work", sectionId: "work", path: "/work" },
+  { href: "/#education", label: "education", sectionId: "education", path: "/education" },
   { href: "/#contact", label: "contact", sectionId: "contact", path: "/contact" },
 ];
 
 export function SiteNav() {
   const pathname = usePathname();
-  const [activeSection, setActiveSection] = useState("home");
+  const [activeSection, setActiveSection] = useState("about");
 
   useEffect(() => {
     if (pathname !== "/") {
@@ -37,7 +37,7 @@ export function SiteNav() {
             id: section.id,
             distance: Math.abs(section.getBoundingClientRect().top - marker),
           }))
-          .sort((a, b) => a.distance - b.distance)[0]?.id ?? "home";
+          .sort((a, b) => a.distance - b.distance)[0]?.id ?? "about";
 
       setActiveSection(currentSection);
     };

--- a/components/site-nav.tsx
+++ b/components/site-nav.tsx
@@ -12,14 +12,19 @@ const navItems = [
   { href: "/#contact", label: "contact", sectionId: "contact", path: "/contact" },
 ];
 
+function getSectionIdForPathname(pathname: string) {
+  return navItems.find((item) => item.path === pathname)?.sectionId ?? "about";
+}
+
 export function SiteNav() {
   const pathname = usePathname();
-  const [activeSection, setActiveSection] = useState("about");
+  const [activeSection, setActiveSection] = useState(() =>
+    getSectionIdForPathname(pathname),
+  );
 
   useEffect(() => {
     if (pathname !== "/") {
-      const matchingItem = navItems.find((item) => item.path === pathname);
-      setActiveSection(matchingItem?.sectionId ?? "");
+      setActiveSection(getSectionIdForPathname(pathname));
       return;
     }
 
@@ -39,7 +44,10 @@ export function SiteNav() {
         return;
       }
 
-      const marker = 140;
+      const header = document.querySelector(".site-header");
+      const headerHeight =
+        header instanceof HTMLElement ? header.getBoundingClientRect().height : 0;
+      const marker = headerHeight + 48;
       const currentSection =
         sectionElements
           .map((section) => ({
@@ -86,7 +94,13 @@ export function SiteNav() {
     }
 
     event.preventDefault();
-    section.scrollIntoView({ behavior: "smooth", block: "start" });
+    const prefersReducedMotion = window.matchMedia(
+      "(prefers-reduced-motion: reduce)",
+    ).matches;
+    section.scrollIntoView({
+      behavior: prefersReducedMotion ? "auto" : "smooth",
+      block: "start",
+    });
     window.history.pushState(null, "", `#${sectionId}`);
     setActiveSection(sectionId);
   };

--- a/components/site-nav.tsx
+++ b/components/site-nav.tsx
@@ -30,6 +30,15 @@ export function SiteNav() {
     let animationFrame = 0;
 
     const updateActiveSection = () => {
+      const lastSection = sectionElements[sectionElements.length - 1];
+      const isAtPageBottom =
+        window.innerHeight + window.scrollY >= document.documentElement.scrollHeight - 2;
+
+      if (isAtPageBottom && lastSection) {
+        setActiveSection(lastSection.id);
+        return;
+      }
+
       const marker = 140;
       const currentSection =
         sectionElements

--- a/components/site-nav.tsx
+++ b/components/site-nav.tsx
@@ -2,26 +2,95 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import type { MouseEvent } from "react";
+import { useEffect, useState } from "react";
 
 const navItems = [
-  { href: "/", label: "home" },
-  { href: "/work", label: "work" },
-  { href: "/about", label: "about" },
-  { href: "/contact", label: "contact" },
+  { href: "/#home", label: "home", sectionId: "home", path: "/" },
+  { href: "/#work", label: "work", sectionId: "work", path: "/work" },
+  { href: "/#about", label: "about", sectionId: "about", path: "/about" },
+  { href: "/#contact", label: "contact", sectionId: "contact", path: "/contact" },
 ];
 
 export function SiteNav() {
   const pathname = usePathname();
+  const [activeSection, setActiveSection] = useState("home");
+
+  useEffect(() => {
+    if (pathname !== "/") {
+      const matchingItem = navItems.find((item) => item.path === pathname);
+      setActiveSection(matchingItem?.sectionId ?? "");
+      return;
+    }
+
+    const sectionElements = navItems
+      .map((item) => document.getElementById(item.sectionId))
+      .filter((section): section is HTMLElement => Boolean(section));
+
+    let animationFrame = 0;
+
+    const updateActiveSection = () => {
+      const marker = 140;
+      const currentSection =
+        sectionElements
+          .map((section) => ({
+            id: section.id,
+            distance: Math.abs(section.getBoundingClientRect().top - marker),
+          }))
+          .sort((a, b) => a.distance - b.distance)[0]?.id ?? "home";
+
+      setActiveSection(currentSection);
+    };
+
+    const requestActiveSectionUpdate = () => {
+      window.cancelAnimationFrame(animationFrame);
+      animationFrame = window.requestAnimationFrame(updateActiveSection);
+    };
+
+    requestActiveSectionUpdate();
+    window.addEventListener("scroll", requestActiveSectionUpdate, {
+      passive: true,
+    });
+    window.addEventListener("resize", requestActiveSectionUpdate);
+    window.addEventListener("hashchange", requestActiveSectionUpdate);
+
+    return () => {
+      window.cancelAnimationFrame(animationFrame);
+      window.removeEventListener("scroll", requestActiveSectionUpdate);
+      window.removeEventListener("resize", requestActiveSectionUpdate);
+      window.removeEventListener("hashchange", requestActiveSectionUpdate);
+    };
+  }, [pathname]);
+
+  const handleNavClick = (
+    event: MouseEvent<HTMLAnchorElement>,
+    sectionId: string,
+  ) => {
+    if (pathname !== "/") {
+      return;
+    }
+
+    const section = document.getElementById(sectionId);
+
+    if (!section) {
+      return;
+    }
+
+    event.preventDefault();
+    section.scrollIntoView({ behavior: "smooth", block: "start" });
+    window.history.pushState(null, "", `#${sectionId}`);
+    setActiveSection(sectionId);
+  };
 
   return (
     <nav aria-label="Primary" className="site-nav">
-      {navItems.map((item, index) => (
+      {navItems.map((item) => (
         <span key={item.href} className="site-nav-item">
-          {index > 0 ? <span aria-hidden="true">/</span> : null}
           <Link
             href={item.href}
-            data-active={pathname === item.href}
-            aria-current={pathname === item.href ? "page" : undefined}
+            data-active={activeSection === item.sectionId}
+            aria-current={activeSection === item.sectionId ? "location" : undefined}
+            onClick={(event) => handleNavClick(event, item.sectionId)}
           >
             {item.label}
           </Link>

--- a/content/about.mdx
+++ b/content/about.mdx
@@ -1,10 +1,6 @@
-import { Subtle } from "@/components/homepage-content";
+import Link from "next/link";
 
 # About
-
-<Subtle>
-  A bit more context about my background and what I care about in software.
-</Subtle>
 
 I'm Ben Desprets, a full-stack developer focused on building clean,
 useful software. I like working across frontend, backend, and product, with an
@@ -17,7 +13,7 @@ emphasis on clarity, maintainability, and calm user experiences.
     <tr>
       <td>2024-2026</td>
       <td>
-        <strong>Software Engineering - Epitech</strong>
+        <Link href="/epitech">Master's in Software Engineering - Epitech</Link>
         <br />
         Expected 2026. Focused on full-stack development, software engineering,
         and production systems.
@@ -26,7 +22,7 @@ emphasis on clarity, maintainability, and calm user experiences.
     <tr>
       <td>2024-2025</td>
       <td>
-        <strong>Management - McGill University</strong>
+        <Link href="/mcgill">Certificate in Management - McGill</Link>
         <br />
         Project management, leadership, finance, and business strategy.
       </td>
@@ -34,7 +30,7 @@ emphasis on clarity, maintainability, and calm user experiences.
     <tr>
       <td>2020-2024</td>
       <td>
-        <strong>Software Engineering - Epitech</strong>
+        <Link href="/epitech">Bachelor's in Software Engineering - Epitech</Link>
         <br />
         International Track program with time in Paris, Berlin, and Montreal.
       </td>

--- a/content/about.mdx
+++ b/content/about.mdx
@@ -12,42 +12,32 @@ emphasis on clarity, maintainability, and calm user experiences.
 
 # Education
 
-<table>
-  <thead>
-    <tr>
-      <th>Years</th>
-      <th>Degree</th>
-      <th>Institution</th>
-    </tr>
-  </thead>
+<table className="education-table compact-table">
   <tbody>
     <tr>
       <td>2024-2026</td>
       <td>
-        <strong>Master's in Software Engineering</strong>
+        <strong>Software Engineering - Epitech</strong>
         <br />
         Expected 2026. Focused on full-stack development, software engineering,
         and production systems.
       </td>
-      <td>Epitech</td>
     </tr>
     <tr>
       <td>2024-2025</td>
       <td>
-        <strong>Certificate in Management</strong>
+        <strong>Management - McGill University</strong>
         <br />
         Project management, leadership, finance, and business strategy.
       </td>
-      <td>McGill University</td>
     </tr>
     <tr>
       <td>2020-2024</td>
       <td>
-        <strong>Bachelor's in Software Engineering</strong>
+        <strong>Software Engineering - Epitech</strong>
         <br />
         International Track program with time in Paris, Berlin, and Montreal.
       </td>
-      <td>Epitech</td>
     </tr>
   </tbody>
 </table>

--- a/content/about.mdx
+++ b/content/about.mdx
@@ -1,39 +1,5 @@
-import Link from "next/link";
-
 # About
 
 I'm Ben Desprets, a full-stack developer focused on building clean,
 useful software. I like working across frontend, backend, and product, with an
 emphasis on clarity, maintainability, and calm user experiences.
-
-# Education
-
-<table className="education-table compact-table">
-  <tbody>
-    <tr>
-      <td>2024-2026</td>
-      <td>
-        <Link href="/epitech">Master's in Software Engineering - Epitech</Link>
-        <br />
-        Expected 2026. Focused on full-stack development, software engineering,
-        and production systems.
-      </td>
-    </tr>
-    <tr>
-      <td>2024-2025</td>
-      <td>
-        <Link href="/mcgill">Certificate in Management - McGill</Link>
-        <br />
-        Project management, leadership, finance, and business strategy.
-      </td>
-    </tr>
-    <tr>
-      <td>2020-2024</td>
-      <td>
-        <Link href="/epitech">Bachelor's in Software Engineering - Epitech</Link>
-        <br />
-        International Track program with time in Paris, Berlin, and Montreal.
-      </td>
-    </tr>
-  </tbody>
-</table>

--- a/content/contact.mdx
+++ b/content/contact.mdx
@@ -4,7 +4,7 @@ import { ExternalLink } from "@/components/homepage-content";
 
 I get a lot of spam in my DMs so the easiest way to reach me is through email.
 
-- Email: <a href="mailto:benjamin.desprets@epitech.eu">benjamin.desprets@epitech.eu</a>
+- 𝕏: <ExternalLink href="https://x.com/bendesprets">bendesprets</ExternalLink>
 - GitHub: <ExternalLink href="https://github.com/bendsp">bendsp</ExternalLink>
 - LinkedIn: <ExternalLink href="https://www.linkedin.com/in/benjamindesprets">benjamindesprets</ExternalLink>
-- 𝕏: <ExternalLink href="https://x.com/bendesprets">bendesprets</ExternalLink>
+- Email: <a href="mailto:benjamin.desprets@epitech.eu">benjamin.desprets@epitech.eu</a>

--- a/content/contact.mdx
+++ b/content/contact.mdx
@@ -2,7 +2,9 @@ import { ExternalLink } from "@/components/homepage-content";
 
 # Contact
 
+I get a lot of spam in my DMs so the easiest way to reach me is through email.
+
 - Email: <a href="mailto:benjamin.desprets@epitech.eu">benjamin.desprets@epitech.eu</a>
 - GitHub: <ExternalLink href="https://github.com/bendsp">bendsp</ExternalLink>
 - LinkedIn: <ExternalLink href="https://www.linkedin.com/in/benjamindesprets">benjamindesprets</ExternalLink>
-- X: <ExternalLink href="https://x.com/bendesprets">bendesprets</ExternalLink>
+- 𝕏: <ExternalLink href="https://x.com/bendesprets">bendesprets</ExternalLink>

--- a/content/contact.mdx
+++ b/content/contact.mdx
@@ -1,10 +1,6 @@
-import { ExternalLink, Subtle } from "@/components/homepage-content";
+import { ExternalLink } from "@/components/homepage-content";
 
 # Contact
-
-<Subtle>
-  The easiest way to reach me is by email. You can also find me here.
-</Subtle>
 
 - Email: <a href="mailto:benjamin.desprets@epitech.eu">benjamin.desprets@epitech.eu</a>
 - GitHub: <ExternalLink href="https://github.com/bendsp">bendsp</ExternalLink>

--- a/content/education.mdx
+++ b/content/education.mdx
@@ -1,0 +1,33 @@
+import Link from "next/link";
+
+# Education
+
+<table className="education-table compact-table">
+  <tbody>
+    <tr>
+      <td>2024-2026</td>
+      <td>
+        <Link href="/epitech">Master's in Software Engineering - Epitech</Link>
+        <br />
+        Expected 2026. Focused on full-stack development, software engineering,
+        and production systems.
+      </td>
+    </tr>
+    <tr>
+      <td>2024-2025</td>
+      <td>
+        <Link href="/mcgill">Certificate in Management - McGill</Link>
+        <br />
+        Project management, leadership, finance, and business strategy.
+      </td>
+    </tr>
+    <tr>
+      <td>2020-2024</td>
+      <td>
+        <Link href="/epitech">Bachelor's in Software Engineering - Epitech</Link>
+        <br />
+        International Track program with time in Paris, Berlin, and Montreal.
+      </td>
+    </tr>
+  </tbody>
+</table>

--- a/content/education.mdx
+++ b/content/education.mdx
@@ -7,7 +7,7 @@ import Link from "next/link";
 <table className="education-table compact-table">
   <tbody>
     <tr>
-      <td>2024-2026</td>
+      <td>2024 - 2026</td>
       <td>
         <Link href="/epitech">Master's in Software Engineering - Epitech</Link>
         <div className="subtle">
@@ -17,7 +17,7 @@ import Link from "next/link";
       </td>
     </tr>
     <tr>
-      <td>2024-2025</td>
+      <td>2024 - 2025</td>
       <td>
         <Link href="/mcgill">Certificate in Management - McGill</Link>
         <div className="subtle">
@@ -26,7 +26,7 @@ import Link from "next/link";
       </td>
     </tr>
     <tr>
-      <td>2020-2024</td>
+      <td>2020 - 2024</td>
       <td>
         <Link href="/epitech">Bachelor's in Software Engineering - Epitech</Link>
         <div className="subtle">

--- a/content/education.mdx
+++ b/content/education.mdx
@@ -2,6 +2,8 @@ import Link from "next/link";
 
 # Education
 
+## Degrees
+
 <table className="education-table compact-table">
   <tbody>
     <tr>

--- a/content/education.mdx
+++ b/content/education.mdx
@@ -10,25 +10,28 @@ import Link from "next/link";
       <td>2024-2026</td>
       <td>
         <Link href="/epitech">Master's in Software Engineering - Epitech</Link>
-        <br />
-        Expected 2026. Focused on full-stack development, software engineering,
-        and production systems.
+        <div className="subtle">
+          Expected 2026. Focused on full-stack development, software engineering,
+          and production systems.
+        </div>
       </td>
     </tr>
     <tr>
       <td>2024-2025</td>
       <td>
         <Link href="/mcgill">Certificate in Management - McGill</Link>
-        <br />
-        Project management, leadership, finance, and business strategy.
+        <div className="subtle">
+          Project management, leadership, finance, and business strategy.
+        </div>
       </td>
     </tr>
     <tr>
       <td>2020-2024</td>
       <td>
         <Link href="/epitech">Bachelor's in Software Engineering - Epitech</Link>
-        <br />
-        International Track program with time in Paris, Berlin, and Montreal.
+        <div className="subtle">
+          International Track program with time in Paris, Berlin, and Montreal.
+        </div>
       </td>
     </tr>
   </tbody>

--- a/content/education.mdx
+++ b/content/education.mdx
@@ -11,8 +11,8 @@ import Link from "next/link";
       <td>
         <Link href="/epitech">Master's in Software Engineering - Epitech</Link>
         <div className="subtle">
-          Expected 2026. Focused on full-stack development, software engineering,
-          and production systems.
+          Focused on full-stack development, software engineering, and
+          production systems.
         </div>
       </td>
     </tr>

--- a/content/homepage.mdx
+++ b/content/homepage.mdx
@@ -8,4 +8,4 @@ I'm currently completing a master's degree in software engineering at
 at <ExternalLink href="https://teiimo.com/">Teiimo</ExternalLink> as a data
 scientist and app developer.
 
-You can check out my [work and projects](/work), [learn about me](/about), or [contact me](/contact).
+You can check out my [work and projects](#work), [learn about me](#about), or [contact me](#contact).

--- a/content/work.mdx
+++ b/content/work.mdx
@@ -3,10 +3,12 @@ import {
   ProjectsSection,
 } from "@/components/homepage-content";
 
-# Client Work
+# Work
+
+## Client Work
 
 <ClientWorkSection />
 
-# Projects
+## Projects
 
 <ProjectsSection />

--- a/mdx-components.tsx
+++ b/mdx-components.tsx
@@ -4,7 +4,6 @@ import {
   ClientWorkSection,
   ExternalLink,
   ProjectsSection,
-  Subtle,
 } from "@/components/homepage-content";
 
 function Table(props: ComponentPropsWithoutRef<"table">) {
@@ -39,7 +38,6 @@ export function useMDXComponents(components: MDXComponents): MDXComponents {
     ClientWorkSection,
     ExternalLink,
     ProjectsSection,
-    Subtle,
     ...components,
   };
 }


### PR DESCRIPTION
## Summary
- Merged the home, work, about, and contact content into one continuous homepage section stack.
- Updated primary navigation to use same-page anchors with smooth scrolling and active-section highlighting.
- Removed the visible slash separators and section divider lines to keep the layout cleaner.

## Testing
- `pnpm exec tsc --noEmit` passed.
- Verified locally in the browser that clicking nav links updates the hash and active state, and that scrolling highlights the current section.
- Restarted the dev server after the build/cache issue and confirmed the app is serving again.