### PR TITLE
Add SEO metadata and structured data

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,5 +1,14 @@
 import AboutContent from "@/content/about.mdx";
 
+export const metadata = {
+  title: "About",
+  description:
+    "About Ben Desprets, a full-stack developer focused on clean, useful software.",
+  alternates: {
+    canonical: "/about",
+  },
+};
+
 export default function AboutPage() {
   return (
     <article className="document-prose prose prose-neutral dark:prose-invert">

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -1,5 +1,14 @@
 import ContactContent from "@/content/contact.mdx";
 
+export const metadata = {
+  title: "Contact",
+  description:
+    "Contact Ben Desprets by email, GitHub, LinkedIn, or X.",
+  alternates: {
+    canonical: "/contact",
+  },
+};
+
 export default function ContactPage() {
   return (
     <article className="document-prose prose prose-neutral dark:prose-invert">

--- a/app/epitech/page.tsx
+++ b/app/epitech/page.tsx
@@ -1,6 +1,9 @@
 export const metadata = {
-  title: "Epitech | Ben Desprets",
+  title: "Epitech",
   description: "Notes on Ben Desprets' software engineering studies at Epitech.",
+  alternates: {
+    canonical: "/epitech",
+  },
 };
 
 export default function EpitechPage() {

--- a/app/eth-investors-club/page.tsx
+++ b/app/eth-investors-club/page.tsx
@@ -1,8 +1,11 @@
 import { ExternalLink } from "@/components/homepage-content";
 
 export const metadata = {
-  title: "ETH Investors Club | Ben Desprets",
+  title: "ETH Investors Club",
   description: "Client work for ETH Investors Club.",
+  alternates: {
+    canonical: "/eth-investors-club",
+  },
 };
 
 export default function EICPage() {

--- a/app/globals.css
+++ b/app/globals.css
@@ -317,6 +317,38 @@
   margin-bottom: 0;
 }
 
+.project-table__stack {
+  margin-top: 0.16rem;
+  color: var(--muted);
+  font-size: 0.88rem;
+  line-height: 1.45;
+}
+
+.project-meta {
+  display: grid;
+  gap: 0.42rem;
+  margin: 0 0 1.35rem;
+  padding: 0.75rem 0;
+  border-top: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
+  font-size: 0.94rem;
+}
+
+.project-meta div {
+  display: grid;
+  grid-template-columns: 5.2rem 1fr;
+  gap: 1rem;
+}
+
+.project-meta dt {
+  color: var(--muted);
+  font-weight: 400;
+}
+
+.project-meta dd {
+  margin: 0;
+}
+
 .education-table td:first-child {
   width: 7.35rem;
   color: var(--muted);
@@ -502,6 +534,11 @@
 
   .compact-table .subtle {
     margin-top: 0.12rem;
+  }
+
+  .project-meta div {
+    grid-template-columns: 4.6rem 1fr;
+    gap: 0.8rem;
   }
 
   .education-table td:first-child {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,13 +2,49 @@ import type { Metadata } from "next";
 import type React from "react";
 import Link from "next/link";
 import "@/app/globals.css";
+import { JsonLd } from "@/components/json-ld";
 import { SiteNav } from "@/components/site-nav";
 import { ThemeProvider } from "@/components/theme-provider";
 import { ThemeToggle } from "@/components/theme-toggle";
+import { getSiteStructuredData } from "@/lib/structured-data";
+import { absoluteUrl, site } from "@/lib/site";
 
 export const metadata: Metadata = {
-  title: "Ben Desprets",
-  description: "I'm Ben, a full-stack developer with a focus on data and engaging design.",
+  metadataBase: new URL(site.url),
+  title: {
+    default: site.name,
+    template: `%s | ${site.name}`,
+  },
+  description: site.description,
+  alternates: {
+    canonical: "/",
+  },
+  authors: [{ name: site.legalName, url: site.url }],
+  creator: site.legalName,
+  keywords: [...site.skills],
+  openGraph: {
+    type: "website",
+    locale: "en_US",
+    url: site.url,
+    siteName: site.name,
+    title: site.name,
+    description: site.description,
+    images: [
+      {
+        url: absoluteUrl(site.image),
+        width: 1200,
+        height: 1200,
+        alt: site.legalName,
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: site.name,
+    description: site.description,
+    creator: "@bendesprets",
+    images: [absoluteUrl(site.image)],
+  },
 };
 
 export default function RootLayout({
@@ -21,6 +57,7 @@ export default function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <body>
+        <JsonLd data={getSiteStructuredData()} />
         <ThemeProvider
           attribute="class"
           defaultTheme="light"

--- a/app/mcgill/page.tsx
+++ b/app/mcgill/page.tsx
@@ -1,6 +1,9 @@
 export const metadata = {
-  title: "McGill | Ben Desprets",
+  title: "McGill",
   description: "Notes on Ben Desprets' management studies at McGill.",
+  alternates: {
+    canonical: "/mcgill",
+  },
 };
 
 export default function McGillPage() {

--- a/app/projects.ts
+++ b/app/projects.ts
@@ -4,6 +4,9 @@ export interface Project {
   years: string;
   description: string;
   technologies: string[];
+  languages: string[];
+  schemaType?: "SoftwareApplication" | "SoftwareSourceCode";
+  ogImage?: string;
   github?: string;
   link?: string;
 }
@@ -15,6 +18,8 @@ export const projects: Project[] = [
     years: "Ongoing",
     description: "Level up your notes with the power of Markdown",
     technologies: ["React", "Tailwind", "TypeScript", "Electron"],
+    languages: ["TypeScript"],
+    ogImage: "/assets/projects/bedrock/01-hero-desktop.webp",
     github: "https://github.com/bendsp/bedrock",
     link: "https://bedrock.desprets.net/",
   },
@@ -31,6 +36,8 @@ export const projects: Project[] = [
       "Clerk",
       "Stripe",
     ],
+    languages: ["TypeScript"],
+    ogImage: "/assets/projects/imagn/01-hero-desktop.webp",
     link: "https://imagn.xyz/",
   },
   {
@@ -39,6 +46,7 @@ export const projects: Project[] = [
     years: "2024 - 2026",
     description: "The easiest wallet in the world!",
     technologies: ["React-Native", "Tailwind", "TypeScript", "Crypto"],
+    languages: ["TypeScript"],
     github: "https://github.com/fdmntl/fundamental-app",
     link: "https://www.fundamentalwallet.com/",
   },
@@ -48,6 +56,8 @@ export const projects: Project[] = [
     years: "2025",
     description: "Find out which emoji has the closest average RGB value",
     technologies: ["React", "Tailwind", "TypeScript"],
+    languages: ["TypeScript"],
+    ogImage: "/assets/projects/emoji-picker/01-hero-desktop.webp",
     github: "https://github.com/bendsp/emoji-color-picker",
     link: "https://emoji.desprets.net/",
   },
@@ -57,6 +67,8 @@ export const projects: Project[] = [
     years: "2025",
     description: "A Pictochat inspired chatroom",
     technologies: ["React-Native", "Tailwind", "TypeScript"],
+    languages: ["TypeScript"],
+    ogImage: "/assets/projects/skribbl-chat/01-hero-desktop.webp",
     github: "https://github.com/bendsp/skribbl.chat",
     link: "https://skribbl.chat/",
   },
@@ -66,6 +78,8 @@ export const projects: Project[] = [
     years: "2023",
     description: "C++ raytracer from scratch",
     technologies: ["C++", "SFML", "libconfig"],
+    languages: ["C++"],
+    schemaType: "SoftwareSourceCode",
     github: "https://github.com/bendsp/RayBeam",
   },
   {
@@ -74,6 +88,8 @@ export const projects: Project[] = [
     years: "Ongoing",
     description: "To understand recursion, one must first understand recursion.",
     technologies: ["React", "Tailwind", "TypeScript"],
+    languages: ["TypeScript"],
+    ogImage: "/assets/projects/desprets-net/01-hero-desktop.webp",
     github: "https://github.com/bendsp/desprets.net",
     link: "https://desprets.net/",
   },

--- a/app/protocol-guild/page.tsx
+++ b/app/protocol-guild/page.tsx
@@ -1,8 +1,11 @@
 import { ExternalLink } from "@/components/homepage-content";
 
 export const metadata = {
-  title: "Protocol Guild | Ben Desprets",
+  title: "Protocol Guild",
   description: "Client work for Protocol Guild.",
+  alternates: {
+    canonical: "/protocol-guild",
+  },
 };
 
 export default function ProtocolGuildPage() {

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,12 @@
+import type { MetadataRoute } from "next";
+import { absoluteUrl } from "@/lib/site";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/",
+    },
+    sitemap: absoluteUrl("/sitemap.xml"),
+  };
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,38 @@
+import type { MetadataRoute } from "next";
+import { clientWork } from "@/app/client-work";
+import { projects } from "@/app/projects";
+import { absoluteUrl } from "@/lib/site";
+
+const staticRoutes = [
+  { path: "/", priority: 1 },
+  { path: "/about", priority: 0.8 },
+  { path: "/work", priority: 0.8 },
+  { path: "/contact", priority: 0.7 },
+  { path: "/epitech", priority: 0.5 },
+  { path: "/mcgill", priority: 0.5 },
+];
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const lastModified = new Date();
+
+  return [
+    ...staticRoutes.map((route) => ({
+      url: absoluteUrl(route.path),
+      lastModified,
+      changeFrequency: "monthly" as const,
+      priority: route.priority,
+    })),
+    ...projects.map((project) => ({
+      url: absoluteUrl(`/${project.slug}`),
+      lastModified,
+      changeFrequency: "monthly" as const,
+      priority: 0.8,
+    })),
+    ...clientWork.map((client) => ({
+      url: absoluteUrl(`/${client.slug}`),
+      lastModified,
+      changeFrequency: "yearly" as const,
+      priority: 0.6,
+    })),
+  ];
+}

--- a/app/teiimo/page.tsx
+++ b/app/teiimo/page.tsx
@@ -1,6 +1,9 @@
 export const metadata = {
-  title: "Teiimo | Ben Desprets",
+  title: "Teiimo",
   description: "Client work for Teiimo.",
+  alternates: {
+    canonical: "/teiimo",
+  },
 };
 
 export default function TeiimoPage() {

--- a/app/work/page.tsx
+++ b/app/work/page.tsx
@@ -1,5 +1,14 @@
 import WorkContent from "@/content/work.mdx";
 
+export const metadata = {
+  title: "Work",
+  description:
+    "Selected client work and software projects by Ben Desprets.",
+  alternates: {
+    canonical: "/work",
+  },
+};
+
 export default function WorkPage() {
   return (
     <article className="document-prose prose prose-neutral dark:prose-invert">

--- a/components/homepage-content.tsx
+++ b/components/homepage-content.tsx
@@ -32,6 +32,9 @@ export function ProjectsSection() {
             <td className="project-table__content">
               <Link href={`/${project.slug}`}>{project.title}</Link>
               <div className="subtle">{project.description}</div>
+              <div className="project-table__stack">
+                {project.technologies.join(", ")}
+              </div>
             </td>
           </tr>
         );

--- a/components/json-ld.tsx
+++ b/components/json-ld.tsx
@@ -1,0 +1,14 @@
+interface JsonLdProps {
+  data: unknown;
+}
+
+export function JsonLd({ data }: JsonLdProps) {
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{
+        __html: JSON.stringify(data).replace(/</g, "\\u003c"),
+      }}
+    />
+  );
+}

--- a/components/project-article.tsx
+++ b/components/project-article.tsx
@@ -2,18 +2,11 @@ import type { ComponentType } from "react";
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { JsonLd } from "@/components/json-ld";
+import { ExternalLink } from "@/components/homepage-content";
 import { projects, type ProjectSlug } from "@/app/projects";
 import { projectArticles } from "@/content/projects";
 import { getProjectStructuredData } from "@/lib/structured-data";
 import { absoluteUrl, site } from "@/lib/site";
-
-const projectImageSlugs = new Set<ProjectSlug>([
-  "bedrock",
-  "desprets-net",
-  "emoji-picker",
-  "imagn",
-  "skribbl-chat",
-]);
 
 function getProject(slug: ProjectSlug) {
   return projects.find((project) => project.slug === slug);
@@ -27,9 +20,7 @@ export function getProjectMetadata(slug: ProjectSlug): Metadata {
   }
 
   const canonical = `/${project.slug}`;
-  const image = projectImageSlugs.has(slug)
-    ? absoluteUrl(`/assets/projects/${project.slug}/01-hero-desktop.webp`)
-    : absoluteUrl(site.image);
+  const image = absoluteUrl(project.ogImage ?? site.image);
 
   return {
     title: project.title,
@@ -88,9 +79,9 @@ export function ProjectArticle({ slug }: ProjectArticleProps) {
           <div>
             <dt>Links</dt>
             <dd>
-              {project.link && <a href={project.link}>Website</a>}
+              {project.link && <ExternalLink href={project.link}>Website</ExternalLink>}
               {project.link && project.github && <span aria-hidden="true"> / </span>}
-              {project.github && <a href={project.github}>Source</a>}
+              {project.github && <ExternalLink href={project.github}>Source</ExternalLink>}
             </dd>
           </div>
         )}

--- a/components/project-article.tsx
+++ b/components/project-article.tsx
@@ -1,8 +1,19 @@
 import type { ComponentType } from "react";
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
+import { JsonLd } from "@/components/json-ld";
 import { projects, type ProjectSlug } from "@/app/projects";
 import { projectArticles } from "@/content/projects";
+import { getProjectStructuredData } from "@/lib/structured-data";
+import { absoluteUrl, site } from "@/lib/site";
+
+const projectImageSlugs = new Set<ProjectSlug>([
+  "bedrock",
+  "desprets-net",
+  "emoji-picker",
+  "imagn",
+  "skribbl-chat",
+]);
 
 function getProject(slug: ProjectSlug) {
   return projects.find((project) => project.slug === slug);
@@ -15,9 +26,36 @@ export function getProjectMetadata(slug: ProjectSlug): Metadata {
     return {};
   }
 
+  const canonical = `/${project.slug}`;
+  const image = projectImageSlugs.has(slug)
+    ? absoluteUrl(`/assets/projects/${project.slug}/01-hero-desktop.webp`)
+    : absoluteUrl(site.image);
+
   return {
-    title: `${project.title} | Ben Desprets`,
+    title: project.title,
     description: project.description,
+    alternates: {
+      canonical,
+    },
+    openGraph: {
+      type: "article",
+      url: absoluteUrl(canonical),
+      siteName: site.name,
+      title: `${project.title} | ${site.name}`,
+      description: project.description,
+      images: [
+        {
+          url: image,
+          alt: project.title,
+        },
+      ],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: `${project.title} | ${site.name}`,
+      description: project.description,
+      images: [image],
+    },
   };
 }
 
@@ -35,7 +73,28 @@ export function ProjectArticle({ slug }: ProjectArticleProps) {
 
   return (
     <article className="document-prose prose prose-neutral dark:prose-invert">
+      <JsonLd data={getProjectStructuredData(project)} />
       <h1>{project.title}</h1>
+      <dl className="project-meta">
+        <div>
+          <dt>Years</dt>
+          <dd>{project.years}</dd>
+        </div>
+        <div>
+          <dt>Stack</dt>
+          <dd>{project.technologies.join(", ")}</dd>
+        </div>
+        {(project.link || project.github) && (
+          <div>
+            <dt>Links</dt>
+            <dd>
+              {project.link && <a href={project.link}>Website</a>}
+              {project.link && project.github && <span aria-hidden="true"> / </span>}
+              {project.github && <a href={project.github}>Source</a>}
+            </dd>
+          </div>
+        )}
+      </dl>
       <Content />
     </article>
   );

--- a/components/theme-provider.tsx
+++ b/components/theme-provider.tsx
@@ -1,4 +1,5 @@
 "use client";
+
 import { ThemeProvider as NextThemesProvider } from "next-themes";
 import type { ReactNode } from "react";
 

--- a/lib/site.ts
+++ b/lib/site.ts
@@ -1,0 +1,30 @@
+export const site = {
+  name: "Ben Desprets",
+  legalName: "Benjamin Desprets",
+  url: "https://desprets.net",
+  description:
+    "Ben Desprets is a full-stack developer focused on data, product engineering, and calm user experiences.",
+  email: "benjamin.desprets@epitech.eu",
+  image: "/headshot.jpg",
+  sameAs: [
+    "https://github.com/bendsp",
+    "https://www.linkedin.com/in/benjamindesprets",
+    "https://x.com/bendesprets",
+  ],
+  skills: [
+    "Full-stack development",
+    "Frontend engineering",
+    "Product engineering",
+    "Data science",
+    "AI applications",
+    "React",
+    "Next.js",
+    "TypeScript",
+    "React Native",
+    "PostgreSQL",
+  ],
+} as const;
+
+export function absoluteUrl(path = "/") {
+  return new URL(path, site.url).toString();
+}

--- a/lib/structured-data.ts
+++ b/lib/structured-data.ts
@@ -60,13 +60,13 @@ export function getSiteStructuredData() {
 export function getProjectStructuredData(project: Project) {
   return {
     "@context": "https://schema.org",
-    "@type": project.slug === "raybeam" ? "SoftwareSourceCode" : "SoftwareApplication",
+    "@type": project.schemaType ?? "SoftwareApplication",
     "@id": `${site.url}/${project.slug}#software`,
     name: project.title,
     description: project.description,
     url: project.link ?? absoluteUrl(`/${project.slug}`),
     codeRepository: project.github,
-    programmingLanguage: project.technologies,
+    programmingLanguage: project.languages,
     keywords: project.technologies,
     author: {
       "@id": personId,

--- a/lib/structured-data.ts
+++ b/lib/structured-data.ts
@@ -1,0 +1,79 @@
+import { projects, type Project } from "@/app/projects";
+import { absoluteUrl, site } from "@/lib/site";
+
+const personId = `${site.url}/#person`;
+
+export function getSiteStructuredData() {
+  return {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "Person",
+        "@id": personId,
+        name: site.legalName,
+        alternateName: site.name,
+        url: site.url,
+        image: absoluteUrl(site.image),
+        email: `mailto:${site.email}`,
+        jobTitle: "Full-Stack Developer",
+        sameAs: site.sameAs,
+        knowsAbout: site.skills,
+        affiliation: [
+          {
+            "@type": "Organization",
+            name: "Teiimo",
+            url: "https://teiimo.com/",
+          },
+          {
+            "@type": "CollegeOrUniversity",
+            name: "Epitech",
+            url: "https://www.epitech.eu/",
+          },
+        ],
+      },
+      {
+        "@type": "WebSite",
+        "@id": `${site.url}/#website`,
+        name: site.name,
+        url: site.url,
+        description: site.description,
+        inLanguage: "en",
+        author: {
+          "@id": personId,
+        },
+      },
+      {
+        "@type": "ItemList",
+        "@id": `${site.url}/#projects`,
+        name: "Software projects by Ben Desprets",
+        itemListElement: projects.map((project, index) => ({
+          "@type": "ListItem",
+          position: index + 1,
+          url: absoluteUrl(`/${project.slug}`),
+          name: project.title,
+        })),
+      },
+    ],
+  };
+}
+
+export function getProjectStructuredData(project: Project) {
+  return {
+    "@context": "https://schema.org",
+    "@type": project.slug === "raybeam" ? "SoftwareSourceCode" : "SoftwareApplication",
+    "@id": `${site.url}/${project.slug}#software`,
+    name: project.title,
+    description: project.description,
+    url: project.link ?? absoluteUrl(`/${project.slug}`),
+    codeRepository: project.github,
+    programmingLanguage: project.technologies,
+    keywords: project.technologies,
+    author: {
+      "@id": personId,
+    },
+    creator: {
+      "@id": personId,
+    },
+    mainEntityOfPage: absoluteUrl(`/${project.slug}`),
+  };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3375,8 +3375,8 @@ snapshots:
       '@typescript-eslint/parser': 8.57.1(eslint@8.57.1)(typescript@5.9.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.57.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.57.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
       eslint-plugin-react-hooks: 5.0.0-canary-7118f5dd7-20230705(eslint@8.57.1)
@@ -3395,7 +3395,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -3406,22 +3406,22 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.57.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.57.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.57.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.57.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.57.1(eslint@8.57.1)(typescript@5.9.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -3432,7 +3432,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.57.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.57.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3


### PR DESCRIPTION
## Summary
- Add SEO metadata across the portfolio, including canonical URLs, Open Graph, and Twitter cards.
- Add `robots.txt`, `sitemap.xml`, and JSON-LD structured data for the site and projects.
- Surface project stack and project links in crawlable HTML.

## Validation
- `pnpm build`
- Reviewed PR #8 feedback and restored `next-themes` before merging into `layout`.
